### PR TITLE
Add possibility to plug 'start' and 'stop' scripts to a launcher

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher.java
@@ -1,0 +1,108 @@
+package org.jenkinsci.plugins.slave_setup;
+
+
+import com.google.common.base.Strings;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.DelegatingComputerLauncher;
+import hudson.slaves.SlaveComputer;
+import hudson.tasks.Shell;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * Implements the custom logic for an on-demand slave, executing scripts before connecting and after disconnecting
+ */
+public class SetupSlaveLauncher extends DelegatingComputerLauncher {
+
+    private final String startScript;
+    private final String stopScript;
+
+    @DataBoundConstructor
+    public SetupSlaveLauncher(ComputerLauncher launcher,
+                              String startScript,
+                              String stopScript) {
+        super(launcher);
+        this.startScript = startScript;
+        this.stopScript = stopScript;
+    }
+
+    /**
+     * Executes a script on the master node, with a bit of tracing.
+     */
+    private void execute(String script, TaskListener listener) throws IOException, InterruptedException {
+        Jenkins jenkins = Jenkins.getInstance();
+
+        if (jenkins == null) {
+            listener.getLogger().println("Jenkins is not ready... doing nothing");
+            return;
+        }
+
+        if (Strings.isNullOrEmpty(script)) {
+            listener.getLogger().println("No script to be executed for this on-demand slave.");
+            return;
+        }
+
+            Launcher launcher = jenkins.getRootPath().createLauncher(listener);
+            Shell shell = new Shell(script);
+            FilePath root = jenkins.getRootPath();
+            FilePath scriptFile = shell.createScriptFile(root);
+            int r = launcher.launch().cmds(shell.buildCommandLine(scriptFile)).stdout(listener).join();
+
+            if (r != 0) {
+                throw new AbortException("Script failed with return code " + Integer.toString(r) + ".");
+            }
+
+            listener.getLogger().println("Script executed successfully.");
+
+    }
+
+    /*
+     * Getters for Jelly
+     */
+    public String getStartScript() {
+        return startScript;
+    }
+
+    public String getStopScript() {
+        return stopScript;
+    }
+
+    /*
+     *  Delegated methods that plug the additional logic for on-demand slaves
+     */
+
+    @Override
+    public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
+        execute(startScript, listener);
+        super.launch(computer, listener);
+    }
+
+    @Override
+    public void afterDisconnect(SlaveComputer computer, TaskListener listener) {
+        super.afterDisconnect(computer, listener);
+
+        try {
+            execute(stopScript, listener);
+        }  catch (Exception e) {
+            listener.getLogger().println("Failed executing script '" + stopScript + "'.");
+            e.printStackTrace(listener.getLogger());
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
+        public String getDisplayName() {
+            return "Start and stop this node on-demand";
+        }
+    }
+
+}
+

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"  xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    <f:entry title="Start script" field="startScript">
+        <f:expandableTextbox  />
+    </f:entry>
+
+    <f:entry title="Stop script" field="stopScript">
+        <f:expandableTextbox  />
+    </f:entry>
+
+    <st:include page="config.jelly" class="hudson.slaves.DelegatingComputerLauncher"/>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-startScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-startScript.html
@@ -1,0 +1,3 @@
+<div>
+    Optional script to be executed on the Master node before the actual connection method is invoked for connecting to the slave.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-stopScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-stopScript.html
@@ -1,0 +1,3 @@
+<div>
+    Optional script to be executed on the Master node after the slave has been disconnected from Jenkins.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+   Wrapper for other launch methods: executes a script (i.e. to provision a VM) before attempting to connect to the slave machine;
+    then launches the Jenkins slave with a launch method of your choice, and after disconnection executes another script
+    (i.e. for shutting down the VM).
+</j:jelly>


### PR DESCRIPTION
this allows for an easy hook for starting and stopping slave machines in case these can be controlled via scripts executed by the master node - such as virtual machines or cloud instances.
The 'start' script is executed before Jenkins attempts to launch the agent on the slave, and the 'stop' script after disconnection.

This was initially conceived as a separate plugin (as it follow a different approach based on slave launchers instead of labels) - see in Jira HOSTING-101 about merging the change into this plugin.