### PR TITLE
Inclusive naming changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>slave-setup</artifactId>
     <packaging>hpi</packaging>
-    <name>Jenkins Slave SetupPlugin</name>
+    <name>Jenkins Agent Setup Plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Slave+Setup+Plugin</url>
     <version>1.12-SNAPSHOT</version>
 

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfig/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:section title="Slave Setups">
-        <f:entry description="${%Slave Setups list}">
+    <f:section title="Agent Setups">
+        <f:entry description="${%Agent Setups list}">
             <f:repeatableProperty field="setupConfigItems" />
         </f:entry>
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-        <f:section title="Slave Setup"> 
+        <f:section title="Agent Setup"> 
               <f:entry title="prepare script" field="prepareScript">
                  <f:expandableTextbox  />
              </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-commandLine.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-commandLine.html
@@ -1,10 +1,10 @@
 <div>
-    Specify the command to be executed on each slave before Jenkins
-    starts using the slave. This executes with the current directory set
+    Specify the command to be executed on each agent before Jenkins
+    starts using the agent. This executes with the current directory set
     to the copied script directory.
 
     <p>
-    Any non-zero exit code will prevent the slave from being used by Jenkins.
+    Any non-zero exit code will prevent the agent from being used by Jenkins.
 
     <p>
     Commands typed in here is executed as a shell script (by using the shell you specified
@@ -13,5 +13,5 @@
 
     <p>
     The script has the environment variables NODE_TO_SETUP_NAME and NODE_TO_SETUP_LABELS at its disposition.
-    They are set to the NODE_NAME and NODE_LABELS of the slave which is being launched.
+    They are set to the NODE_NAME and NODE_LABELS of the agent which is being launched.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-filesDir.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-filesDir.html
@@ -1,5 +1,5 @@
 <div>
     Specify the directory on the master that contains the setup script file, and
-    any other files that's needed by that script. Whenever a new slave comes online, this
+    any other files that's needed by that script. Whenever a new agent comes online, this
     directory is recursively copied to it and then the script gets executed.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-prepareScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupConfigItem/help-prepareScript.html
@@ -1,9 +1,9 @@
 <div>
     Specify the command to be executed on the master before Jenkins
-    starts using the slave. This executes in JENKINS_HOME.
+    starts using the agent. This executes in JENKINS_HOME.
 
     <p>
-    Any non-zero exit code will prevent the command to prepare the slave from being executed.
+    Any non-zero exit code will prevent the command to prepare the agent from being executed.
 
     <p>
     Commands typed in here is executed as a shell script (by using the shell you specified
@@ -12,5 +12,5 @@
 
     <p>
     The script has the environment variables NODE_TO_SETUP_NAME and NODE_TO_SETUP_LABELS at its disposition.
-    They are set to the NODE_NAME and NODE_LABELS of the slave which is being launched.
+    They are set to the NODE_NAME and NODE_LABELS of the agent which is being launched.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-startScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-startScript.html
@@ -1,3 +1,3 @@
 <div>
-    Optional script to be executed on the Master node before the actual connection method is invoked for connecting to the slave.
+    Optional script to be executed on the Master node before the actual connection method is invoked for connecting to the agent.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-stopScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help-stopScript.html
@@ -1,3 +1,3 @@
 <div>
-    Optional script to be executed on the Master node after the slave has been disconnected from Jenkins.
+    Optional script to be executed on the Master node after the agent has been disconnected from Jenkins.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher/help.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-   Wrapper for other launch methods: executes a script (i.e. to provision a VM) before attempting to connect to the slave machine;
-    then launches the Jenkins slave with a launch method of your choice, and after disconnection executes another script
+   Wrapper for other launch methods: executes a script (i.e. to provision a VM) before attempting to connect to the agent machine;
+    then launches the Jenkins agent with a launch method of your choice, and after disconnection executes another script
     (i.e. for shutting down the VM).
 </j:jelly>


### PR DESCRIPTION
## Inclusive naming changes

The Jenkins project is replacing less inclusive terminology like 'master', 'slave', 'whitelist', and 'blacklist' with more inclusive terminology.  See www.jenkins.io for more details.

- Change plugin name 'Jenkins Agent Setup'
- Replace slave with agent in HTML help files
- Slave -> agent in jelly files

Update plugin for more inclusive naming.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
