### PR TITLE
Fix release process by restoring groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ files and execute scripts before the agents are used.
 
 It also allows you to start and stop agents on demand from the controller.
 
+## Untested changes
+
+Release 1.10 (April 2016) is the **most recent release of this plugin** to the Jenkins update center.
+All changes after the 1.10 tag have not been seen by Jenkins users.
+Before those changes are released, they need to be tested for compatibility and correctness.
+
+One of the untested changes modified the maven coordinates of the plugin.
+That change prevented the delivery of release 1.11, 1.12, and 1.13 to the Jenkins update center.
+That change has been reverted, but no further testing has been performed to check the rest of the modified functionality.
+
+If someone adopts this plugin and performs that testing, then this section should be removed from the documentation so that the README can be used as the plugin documentation on plugins.jenkins.io.
+
 ## Label-based setup
 
 The agent setup plugin gets executed for an agent, if the given label

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <relativePath />
     </parent>
 
-    <groupId>io.jenkins.plugins</groupId>
     <artifactId>slave-setup</artifactId>
     <packaging>hpi</packaging>
     <name>Agent Setup</name>


### PR DESCRIPTION
## Fix the release process by restoring original groupId

- Return to original plugin groupId
- Describe untested changes in the README

The plugin groupId was changed in the pom file after the release of 1.10.  That change caused the release of 1.11 and 1.12 to fail.  The last release available from the Jenkins update center is 1.10.

There have been significant changes in the master branch of the plugin since the release of 1.10.  Rather than risk breaking compatibility for existing users of the 1.10 release, I've removed the incorrect change of groupId and accepted that this plugin cannot be released without testing those changes.

I'm not a user of the plugin.  I'm not willing to perform that testing.  If someone else wants to adopt the plugin, perform the additional testing, and release a new version, this change is a necessary but not sufficient step towards that release.

Compare the current code to the 1.10 tag for the details of the changes made since the 1.10 release.

https://issues.jenkins.io/browse/JENKINS-70301 describes the relationship between this plugin and the WMI Windows Agents plugin.  Users that want to remove the WMI Windows Agents plugin will also need to remove this plugin or they will need to wait until https://github.com/jenkinsci/jenkins/pull/7568 is available in Jenkins core 2.386 or newer.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
