### PR TITLE
[JENKINS-70622] Do not remove temporary Unix files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/Components.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.SystemUtils;
 
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -249,7 +248,6 @@ public class Components {
             try {
                 Components manager = new Components(slave);
                 manager.doConfig();
-                manager.clearTemporally();
             } catch (Exception ex) {
                 Components.info(String.format("Failed to configure %s%nErr:%s", slave.getName(), ex.getMessage()));
                 succeded = false;
@@ -275,7 +273,6 @@ public class Components {
             try {
                 Components manager = new Components(slave);
                 manager.doSetup();
-                manager.clearTemporally();
             } catch (Exception ex) {
                 Components.info(String.format("Failed to configure %s%nErr:%s", slave.getName(), ex.getMessage()));
                 succeded = false;
@@ -314,39 +311,6 @@ public class Components {
         }
         // Add to cache in order to prevent reinstall this version.
         this.addCache(installInfo.remoteCache());
-    }
-
-    /**
-     * Only works on Unix Operating Systems, this will use some unix commands to
-     * clear temporally data
-     * 
-     * If file has more than 5 minutes in the last modified tag, it will be removed.
-     * Only will remove files which name is jenkins
-     * 
-     * This function require at least (find) binary to be installed
-     * 
-     * @throws InterruptedException Broken pipe.
-     * @throws IOException          IO error accessing remotePath
-     * @throws AbortException       User close/Cancelled
-     * 
-     */
-    public void clearTemporally() throws AbortException, IOException, InterruptedException {
-
-        String clearTmp = "find /tmp -type f -atime +10 -delete -iname *jenkins*.sh -maxdepth 0";
-        EnvVars environ = SetupDeployer.createEnvVarsForComputer(this.slave);
-
-        if (this.remotePath.getRemote().startsWith("/")) {
-            // Clear slave temporally data
-            Components.info("Clearing temporally data on " + this.slave.getName());
-            validateResponse(Utils.multiOsExecutor(Components.listener, clearTmp, this.remotePath, environ));
-        }
-
-        if (SystemUtils.IS_OS_UNIX) {
-            // Clear master temporally data
-            Components.info("Clearing temporally data on jenkins master");
-            validateResponse(SetupDeployer.executeScriptOnMaster(Components.listener, clearTmp, environ));
-        }
-        Components.debug("Finished temporal data removed");
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/slave_setup/ComputerListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/slave_setup/ComputerListenerImpl.java
@@ -43,8 +43,6 @@ public class ComputerListenerImpl extends ComputerListener {
 
         manager.doSetup();
         Components.debug("Setup Ended");
-
-        manager.clearTemporally();
     }
 
 }


### PR DESCRIPTION
## [JENKINS-70622] Do not remove temporary files on Unix

#11 was merged 5 years ago but only released in 1.15 Feb 2023.  That change includes a cleanup step that removes specifically named files from the /tmp folder using a Linux specific find command.  There is not enough benefit from that cleanup step to justify the loss of portability to other Unix systems like macOS and Solaris.

[JENKINS-70622](https://issues.jenkins.io/browse/JENKINS-70622) reported the issue on Solaris, AIX, and HP variants of Unix.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
